### PR TITLE
Tweak/simplify web setup instructions

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -32,7 +32,8 @@ sudo apt install yarn
 Alternatively, if you're using nvm, you can run `npm install -g yarn` to install yarn
 in your current node environment (without root access).
 
-In `./web` run `yarn install`.
+In `./web` run `yarn install`. This will install dependencies, including the Gatsby CLI, 
+which you can run with `yarn` (below) or directly using [`npx`](https://www.npmjs.com/package/npx).
 
 
 ## Developing and Running


### PR DESCRIPTION
Noticed the gatsby instructions added in #8 - yarn already installs gatsby, so you just need to point to it somehow. (`npx gatsby` would also work, but I didn't want to add a ton of alternate commands that do the same thing.)
Also fixed a couple things that looked good in the source but wound up on the same line when rendered