### PR TITLE
API Stream URLs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -77,4 +77,3 @@ def stream(city):
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0")
-


### PR DESCRIPTION
The new route is `GET /streams/<city>`.

To be merged after #40 