### PR TITLE
Serve comparison graph data with uniform sampling

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -63,16 +63,18 @@ def pdi_all():
 
     Returns:
         {
-            "cities": {
-                "<city>": {
-                    "time": [...],
-                    "normalized_pdi": [...],
+            "data": [
+                {
+                    "time": time,
+                    "<city1>": <normalized-pdi>,
+                    "<city2>": <normalized-pdi>,
+                    ...
                 },
                 ...
-            }
+            ]
         }
     '''
-    return {"cities": pana.get_all_pdi_graph_data()}
+    return {"data": pana.get_all_pdi_graph_data()}
 
 
 @app.route("/streams/<city>")

--- a/pandemic51/core/api.py
+++ b/pandemic51/core/api.py
@@ -89,13 +89,15 @@ def get_all_pdi_graph_data():
     single graph.
 
     Returns:
-        {
-            "<city>": {
-                "time": [...],
-                "normalized_pdi": [...],
+        [
+            {
+                "time": time,
+                "<city1>": <normalized-pdi>,
+                "<city2>": <normalized-pdi>,
+                ...
             },
             ...
-        }
+        ]
     '''
     streams_to_cities = {v: k for k, v in panc.STREAMS_MAP.items()}
 
@@ -103,18 +105,19 @@ def get_all_pdi_graph_data():
     all_pdi = pand.query_all_pdi()
 
     # Normalize PDI values
-    graph_data = {}
+    norm_pdi = {}
     for stream_name, data in all_pdi.items():
         if stream_name not in streams_to_cities:
             continue
 
         city = streams_to_cities[stream_name]
-        graph_data[city] = {
+        norm_pdi[city] = {
             "time": data["time"],
-            "normalized_pdi": panp.normalize_pdi_values(data["pdi"]),
+            "pdi": panp.normalize_pdi_values(data["pdi"]),
         }
 
-    return graph_data
+    # Resample to uniform times
+    return panp.resample_pdis(norm_pdi)
 
 
 def get_stream_url(city):

--- a/pandemic51/core/pdi.py
+++ b/pandemic51/core/pdi.py
@@ -96,7 +96,7 @@ def resample_pdis(pdis_map, num_samples=150, start_date=ALL_GRAPH_START_DATE):
     timestamps = np.linspace(
         start_timestamp, stop_timestamp, num=num_samples, dtype=int)
 
-    samples = [{"time": t} for t in timestamps]
+    samples = [{"time": int(t)} for t in timestamps]
     for key, data in pdis_map.items():
         f = spi.interp1d(
             data["time"], data["pdi"], kind="linear", bounds_error=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pandas==1.0.3
 Pillow==7.0.0
 PyMySQL==0.9.3
 redis==3.4.1
+scipy==0.19.1
 selenium==3.141.0
 tensorflow==1.15.2


### PR DESCRIPTION
`/api/pdi-all` now serves data with uniformly sampled times in the following format, which is optimized for rechart:

```
{
    "data": [
        {
            "time": <time>,
            "<city1>": <normalized-pdi>,
            "<city2>": <normalized-pdi>,
            ...
        },
        ...
    ]
}
```

It is currently configured to return 150 samples uniformly spaced between Feb 1st and the most recent data sample, although this can be easily customized.

Example output below. `None` denotes missing data, e.g., if the timestamp lies before or after the available data for the city:

```
{
  'time': 1585512211,
  'chicago': 0.7555340511189017,
  'dublin': 0.1557132000194474,
  'fortlauderdale': None,
  'london': None, 
  'newjersey': 0.38171810432999015,
  'neworleans': 0.2153596735653911,
  'newyork': 0.44537050048241517,
  'prague': 0.13533262486884579,
}
```