### PR TITLE
Fix theme color

### DIFF
--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -32,7 +32,7 @@ module.exports = {
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,
-        theme_color: `#663399`,
+        theme_color: `#ff6d04`,
         display: `minimal-ui`,
         icon: `src/images/logo.png`, // This path is relative to the root of the site.
       },


### PR DESCRIPTION
Mobile chrome's title bar was purple before:

![Screenshot_20200331-103158](https://user-images.githubusercontent.com/3719547/78038855-571cee80-733b-11ea-9115-3dee3b287715.jpg)

after:

![Screenshot_20200331-103258](https://user-images.githubusercontent.com/3719547/78038869-5b490c00-733b-11ea-905f-9f37272908e3.jpg)
