### PR TITLE
Make images on mobile show on touch-end events

### DIFF
--- a/web/src/components/chart.js
+++ b/web/src/components/chart.js
@@ -177,6 +177,8 @@ class Chart extends Component {
               margin={{ top: 0, right: 0, left: 30, bottom: 0 }}
               cursor="pointer"
               onClick={this.handleClick.bind(this)}
+              onMouseUp={this.handleClick.bind(this)}
+              onTouchEnd={this.handleClick.bind(this)}
             >
               <defs>
                 <linearGradient id="colorSdi" x1="0" y1="0" x2="0" y2="1">

--- a/web/src/components/layout.js
+++ b/web/src/components/layout.js
@@ -106,8 +106,7 @@ class Layout extends React.Component {
                       <Chart
                         title="Physical Distancing Index (PDI)"
                         city={city}
-                        // todo: use correct image url
-                        onClick={_ => this.setState({ src: _ })}
+                        onClick={src => this.setState({ src })}
                       />
                     </Grid>
                   </Grid>


### PR DESCRIPTION
Closes #52

`mouseup` was actually the one that worked for me, but leaving
support for `touchend` for other browsers, just in case.