### PR TITLE
Celery timeout on `download_stream_task`

### DIFF
--- a/pandemic51/core/tasks.py
+++ b/pandemic51/core/tasks.py
@@ -34,7 +34,7 @@ def setup_periodic_tasks(sender, **kwargs):
         panc.COMPUTE_DETECTIONS_INTERVAL, compute_detections_task.s())
 
 
-@app.task(time_limit=60*5)
+@app.task(time_limit=120)
 def download_stream_task(stream_name):
     '''Downloads and stores images for the given stream.
 

--- a/pandemic51/core/tasks.py
+++ b/pandemic51/core/tasks.py
@@ -34,7 +34,7 @@ def setup_periodic_tasks(sender, **kwargs):
         panc.COMPUTE_DETECTIONS_INTERVAL, compute_detections_task.s())
 
 
-@app.task()
+@app.task(time_limit=60*5)
 def download_stream_task(stream_name):
     '''Downloads and stores images for the given stream.
 


### PR DESCRIPTION
I added this on prod and I'm going to let it run for a bit before merging. This task seems to hang occasionally and then it blocks the entire celery beat process.