### PR TITLE
Add examples for downloading Michigan streams

### DIFF
--- a/tests/download_and_store/example_image_stream_download.py
+++ b/tests/download_and_store/example_image_stream_download.py
@@ -1,0 +1,52 @@
+'''
+Run this every 15 minutes to get the current image that is being displayed
+(this is not a livestream)
+
+Copyright 2020 Voxel51, Inc.
+voxel51.com
+'''
+import io
+import requests
+
+from bs4 import BeautifulSoup
+import numpy as np
+from PIL import Image
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.chrome.options import Options
+
+import eta.core.image as etai
+
+
+# Ypsilanti (EMU Campus)
+webpage = "https://www.weatherbug.com/weather-camera/?cam=PSLNM"
+
+# Get the source from the page
+caps = DesiredCapabilities.CHROME
+caps["goog:loggingPrefs"] = {"performance": "ALL"}
+chrome_options = Options()
+chrome_options.add_argument("--headless")
+driver = webdriver.Chrome(
+    desired_capabilities=caps, options=chrome_options,
+    executable_path="/usr/bin/chromedriver")
+driver.get(webpage)
+
+# Parse the source HTML for images with PSLNM in the title
+soup = BeautifulSoup(driver.page_source, 'html.parser')
+driver.service.stop()
+img_tags = soup.find_all('img')
+urls = [img['src'] for img in img_tags]
+filtered_urls = [u for u in urls if "PSLNM" in u]
+
+for url in filtered_urls:
+    # Get the large version of the image instead of the thumbnail
+    url = url[:-5]+"l"+url[-4:]
+    data = requests.get(url).content
+    img = np.array(Image.open(io.BytesIO(data)))
+    time = url.split("/")[-1].split("_")[0]
+    print("Downloading url")
+    etai.write(img, "out/ypsilanti_"+time+".jpg")
+
+if len(filtered_urls) == 0:
+    print("No matching images found")
+

--- a/tests/download_and_store/example_image_stream_download.py
+++ b/tests/download_and_store/example_image_stream_download.py
@@ -8,34 +8,18 @@ voxel51.com
 import io
 import requests
 
-from bs4 import BeautifulSoup
 import numpy as np
 from PIL import Image
-from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from selenium.webdriver.chrome.options import Options
 
 import eta.core.image as etai
+import pandemic51.core.streaming as pans
 
 
 # Ypsilanti (EMU Campus)
 webpage = "https://www.weatherbug.com/weather-camera/?cam=PSLNM"
 
 # Get the source from the page
-caps = DesiredCapabilities.CHROME
-caps["goog:loggingPrefs"] = {"performance": "ALL"}
-chrome_options = Options()
-chrome_options.add_argument("--headless")
-driver = webdriver.Chrome(
-    desired_capabilities=caps, options=chrome_options,
-    executable_path="/usr/bin/chromedriver")
-driver.get(webpage)
-
-# Parse the source HTML for images with PSLNM in the title
-soup = BeautifulSoup(driver.page_source, 'html.parser')
-driver.service.stop()
-img_tags = soup.find_all('img')
-urls = [img['src'] for img in img_tags]
+urls = pans.get_img_urls(webpage)
 filtered_urls = [u for u in urls if "PSLNM" in u]
 
 for url in filtered_urls:
@@ -45,7 +29,7 @@ for url in filtered_urls:
     img = np.array(Image.open(io.BytesIO(data)))
     time = url.split("/")[-1].split("_")[0]
     print("Downloading url")
-    etai.write(img, "out/ypsilanti_"+time+".jpg")
+    etai.write(img, "out/ypsilanti/"+time+".jpg")
 
 if len(filtered_urls) == 0:
     print("No matching images found")

--- a/tests/download_and_store/example_mjpg_stream_download.py
+++ b/tests/download_and_store/example_mjpg_stream_download.py
@@ -1,7 +1,7 @@
 '''
 Example script for downloading mjpg streams in realtime as a sequence of
-frames. This will continue to download until a termination signal is received
-(Ctrl+C). 
+frames. Either download only the most recent frame or download frames in real
+time until the process is terminated. 
 
 Copyright 2020 Voxel51, Inc.
 voxel51.com

--- a/tests/download_and_store/example_mjpg_stream_download.py
+++ b/tests/download_and_store/example_mjpg_stream_download.py
@@ -12,6 +12,18 @@ import os
 import ffmpy
 
 import eta.core.utils as etau
+import pandemic51.core.streaming as pans
+
+
+def stream_frames(input_video, base_output_dir):
+    output_frames_path = os.path.join("out", base_output_dir, "%Y-%m-%d_%H-%M-%S.jpg")
+    etau.ensure_basedir(output_frames_path)
+    
+    ffmpy.FFmpeg(
+        inputs={input_video: None},
+        outputs={output_frames_path: "-strftime 1"},
+    ).run()
+
 
 # Ann Arbor
 input_video = "http://141.213.137.162/mjpg/video.mjpg"
@@ -21,12 +33,15 @@ base_output_dir = "ann_arbor"
 #input_video = "http://216.8.159.21/axis-cgi/mjpg/video.cgi"
 #base_output_dir = "detroit"
 
-output_frames_path = os.path.join("out", base_output_dir, "%Y-%m-%d_%H-%M-%S.jpg")
+
+# Capture the current frame of the stream
+output_frames_path = os.path.join("out", base_output_dir,
+        str(datetime.now()).replace(" ", "_")+".jpg")
 etau.ensure_basedir(output_frames_path)
 
-ffmpy.FFmpeg(
-    inputs={input_video: None},
-    outputs={output_frames_path: "-strftime 1"},
-).run()
+pans.sample_first_frame(input_video, output_frames_path)
 
+
+## Continually stream frames as images
+#stream_frames(input_video, base_output_dir)
 

--- a/tests/download_and_store/example_mjpg_stream_download.py
+++ b/tests/download_and_store/example_mjpg_stream_download.py
@@ -1,0 +1,32 @@
+'''
+Example script for downloading mjpg streams in realtime as a sequence of
+frames. This will continue to download until a termination signal is recieved
+(Ctrl+C). 
+
+Copyright 2020 Voxel51, Inc.
+voxel51.com
+'''
+from datetime import datetime
+import os
+
+import ffmpy
+
+import eta.core.utils as etau
+
+# Ann Arbor
+input_video = "http://141.213.137.162/mjpg/video.mjpg"
+base_output_dir = "ann_arbor"
+
+## Detroit
+#input_video = "http://216.8.159.21/axis-cgi/mjpg/video.cgi"
+#base_output_dir = "detroit"
+
+output_frames_path = os.path.join("out", base_output_dir, "%Y-%m-%d_%H-%M-%S.jpg")
+etau.ensure_basedir(output_frames_path)
+
+ffmpy.FFmpeg(
+    inputs={input_video: None},
+    outputs={output_frames_path: "-strftime 1"},
+).run()
+
+

--- a/tests/download_and_store/example_mjpg_stream_download.py
+++ b/tests/download_and_store/example_mjpg_stream_download.py
@@ -1,12 +1,11 @@
 '''
 Example script for downloading mjpg streams in realtime as a sequence of
-frames. This will continue to download until a termination signal is recieved
+frames. This will continue to download until a termination signal is received
 (Ctrl+C). 
 
 Copyright 2020 Voxel51, Inc.
 voxel51.com
 '''
-from datetime import datetime
 import os
 
 import ffmpy
@@ -21,7 +20,8 @@ base_output_dir = "ann_arbor"
 #input_video = "http://216.8.159.21/axis-cgi/mjpg/video.cgi"
 #base_output_dir = "detroit"
 
-output_frames_path = os.path.join("out", base_output_dir, "%Y-%m-%d_%H-%M-%S.jpg")
+output_frames_path = os.path.join(
+    "out", base_output_dir, "%Y-%m-%d_%H-%M-%S.jpg")
 etau.ensure_basedir(output_frames_path)
 
 ffmpy.FFmpeg(


### PR DESCRIPTION
There are two example files in `pandemic51/tests/download_and_store/`. 
One that can download `mjpg` streams and one that can download a specific image when requested.

Ann Arbor and Detroit cameras are from ip cameras streaming in `mjpg` format. 
These streams are downloaded through FFmpeg as timestamped frame images continuously until the FFmpeg process is killed.

The Ypsilanti data is not a stream but an image that is updated every 15 minutes. 
The corresponding example for this data opens the Ypsilanti page and finds the image url and saves it.