### PR TITLE
Add support for YouTube streams

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ redis==3.4.1
 scipy==0.19.1
 selenium==3.141.0
 tensorflow==1.15.2
+youtube-dl==2020.3.24

--- a/tests/stream/test_youtube.py
+++ b/tests/stream/test_youtube.py
@@ -18,10 +18,14 @@ print(stream)
 
 print("The livestream URL for embedding is: %s" % stream.get_live_stream_url())
 
+print("The m3u8 stream URL is: %s" % stream.get_m3u8_url())
+
 print("Getting an image")
 
 path, dt = stream.download_image_and_store(outdir=OUT_BASEDIR)
 
 print("Stored it at %s" % path)
+
+print("The m3u8 stream URL is: %s" % stream.get_m3u8_url(force=True))
 
 print("Done")

--- a/tests/stream/test_youtube.py
+++ b/tests/stream/test_youtube.py
@@ -1,0 +1,27 @@
+'''
+Test script for `pandemic51.core.streaming.YouTubeStream`
+
+Copyright 2020 Voxel51, Inc.
+voxel51.com
+'''
+import pandemic51.core.streaming as pans
+
+
+OUT_BASEDIR = "/tmp"
+
+
+print("Creating the stream")
+
+stream = pans.Stream.from_json("./youtube-test.json")
+
+print(stream)
+
+print("The livestream URL for embedding is: %s" % stream.get_live_stream_url())
+
+print("Getting an image")
+
+path, dt = stream.download_image_and_store(outdir=OUT_BASEDIR)
+
+print("Stored it at %s" % path)
+
+print("Done")

--- a/tests/stream/youtube-test.json
+++ b/tests/stream/youtube-test.json
@@ -1,0 +1,6 @@
+{
+    "type": "pandemic51.core.streaming.YouTubeStream",
+    "stream_name": "bryant_park_nyc",
+    "GMT": "-4",
+    "youtube_id": "0uA1tv6MFB0"
+}


### PR DESCRIPTION
This PR adds support for this access YouTube streams; this is backend support.

Be sure to either `pip install -r requirements.txt` or `pip install youtube-dl`.

The new class implements the Stream interface and provides access to the underlying stream as needed.

Tests are in the `tests/stream` for a Bryant Park NYC stream.

Follows the conventions in the codebase as closely as possible.