### PR TITLE
I swear I know how to spell "always"

### DIFF
--- a/config/streams/abbey_road.json
+++ b/config/streams/abbey_road.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "abbey_road",
     "GMT": "0",
-    "webpage": "https://www.earthcam.com/world/england/london/abbeyroad/?cam=abbeyroad_uk",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/AbbeyRoadHD1.flv/chunklist_w1598844980.m3u8"
+    "webpage": "https://www.earthcam.com/world/england/london/abbeyroad/?cam=abbeyroad_uk"
 }

--- a/config/streams/brighton.json
+++ b/config/streams/brighton.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "brighton",
     "GMT": "-4",
-    "webpage": "https://www.earthcam.com/usa/michigan/brighton/?cam=brighton",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/8584.flv/chunklist_w1584477530.m3u8"
+    "webpage": "https://www.earthcam.com/usa/michigan/brighton/?cam=brighton"
 }

--- a/config/streams/chicago.json
+++ b/config/streams/chicago.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "chicago",
     "GMT": "-5",
-    "webpage": "https://www.earthcam.com/usa/illinois/chicago/wrigleyfield/?cam=wrigleyfield_hd",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/13661.flv/chunklist_w1389468755.m3u8"
+    "webpage": "https://www.earthcam.com/usa/illinois/chicago/wrigleyfield/?cam=wrigleyfield_hd"
 }

--- a/config/streams/dublin.json
+++ b/config/streams/dublin.json
@@ -1,6 +1,6 @@
 {
     "type": "pandemic51.core.streaming.M3U8Stream",
-    "webpage": "https://www.earthcam.com/world/ireland/dublin/?cam=templebar",
-    "chunk_path": "https://d3o4twxzdiwvsf.cloudfront.net/fecnetwork/4054.flv/chunklist.m3u8",
-    "GMT": "0"
+    "stream_name": "dublin",
+    "GMT": "0",
+    "webpage": "https://www.earthcam.com/world/ireland/dublin/?cam=templebar"
 }

--- a/config/streams/fort_lauderdale.json
+++ b/config/streams/fort_lauderdale.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "fort_lauderdale",
     "GMT": "-4",
-    "webpage": "https://www.earthcam.com/usa/florida/lauderdalebythesea/?cam=windjammer",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/windjammerHD2.flv/chunklist_w48410317.m3u8"
+    "webpage": "https://www.earthcam.com/usa/florida/lauderdalebythesea/?cam=windjammer"
 }

--- a/config/streams/las_vegas.json
+++ b/config/streams/las_vegas.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "las_vegas",
     "GMT": "-7",
-    "webpage": "https://www.earthcam.com/usa/nevada/lasvegas/index.php?cam=catsmeow_lv_fremont",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/16812.flv/chunklist_w1215431188.m3u8"
+    "webpage": "https://www.earthcam.com/usa/nevada/lasvegas/index.php?cam=catsmeow_lv_fremont"
 }

--- a/config/streams/miami.json
+++ b/config/streams/miami.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "miami",
     "GMT": "-4",
-    "webpage": "https://www.earthcam.com/usa/florida/miamiandthebeaches/?cam=miamibeach9",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/13866.flv/chunklist_w1256622345.m3u8"
+    "webpage": "https://www.earthcam.com/usa/florida/miamiandthebeaches/?cam=miamibeach9"
 }

--- a/config/streams/new_jersey.json
+++ b/config/streams/new_jersey.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "new_jersey",
     "GMT": "-4",
-    "webpage": "https://www.earthcam.com/usa/newjersey/seasideheights/?cam=seasideheights",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/5173.flv/chunklist_w1426956760.m3u8"
+    "webpage": "https://www.earthcam.com/usa/newjersey/seasideheights/?cam=seasideheights"
 }

--- a/config/streams/new_orleans.json
+++ b/config/streams/new_orleans.json
@@ -1,6 +1,6 @@
 {
     "type": "pandemic51.core.streaming.M3U8Stream",
-    "webpage": "https://www.earthcam.com/usa/louisiana/neworleans/bourbonstreet/?cam=bourbonstreet",
-    "chunk_path": "https://video2archives.earthcam.com/archives/_definst_/MP4:permanent/catsmeow_4280/2017/12/12/1300.mp4/chunklist_w1718408182.m3u8",
-    "GMT": "-4"
+    "stream_name": "new_orleans",
+    "GMT": "-4",
+    "webpage": "https://www.earthcam.com/usa/louisiana/neworleans/bourbonstreet/?cam=bourbonstreet"
 }

--- a/config/streams/prague.json
+++ b/config/streams/prague.json
@@ -2,6 +2,5 @@
     "type": "pandemic51.core.streaming.M3U8Stream",
     "stream_name": "prague",
     "GMT": "1",
-    "webpage": "https://www.earthcam.com/world/czechrepublic/prague/?cam=grandhotel_str",
-    "chunk_path": "https://videos-3.earthcam.com/fecnetwork/14191.flv/chunklist_w1342636755.m3u8"
+    "webpage": "https://www.earthcam.com/world/czechrepublic/prague/?cam=grandhotel_str"
 }

--- a/config/streams/time_square.json
+++ b/config/streams/time_square.json
@@ -1,6 +1,6 @@
 {
     "type": "pandemic51.core.streaming.M3U8Stream",
-    "webpage": "https://www.earthcam.com/usa/newyork/timessquare/?cam=tsrobo1",
-    "chunk_path": "https://d3o4twxzdiwvsf.cloudfront.net/fecnetwork/hdtimes10.flv/chunklist.m3u8",
-    "GMT": "-4"
+    "stream_name": "time_square",
+    "GMT": "-4",
+    "webpage": "https://www.earthcam.com/usa/newyork/timessquare/?cam=tsrobo1"
 }

--- a/pandemic51/core/streaming.py
+++ b/pandemic51/core/streaming.py
@@ -281,6 +281,10 @@ class M3U8Stream(Stream):
             # Download video
             video_path, dt = self.download_chunk(tmpdir)
 
+            if not video_path:
+                # this is archival data, so don't return an image
+                return False, None, dt
+
             # UTC integer timestamp (epoch time)
             timestamp = int(dt.timestamp())
 
@@ -297,10 +301,20 @@ class M3U8Stream(Stream):
 
         Args:
             output_dir: the output directory
+
+        Returns:
+            tuple of:
+                - path to the downloaded video chunk
+                    OR None if the stream is an archive stream
+                - the datetime when the video chunk was downloaded
         '''
         output_path = os.path.join(output_dir, self.stream_name)
 
         uris, chunk_path = self.get_uris_and_chunk_path()
+
+        if "archive" in chunk_path:
+            return None, datetime.utcnow()
+
         uri = uris[-1]
 
         logger.info("Processing URI '%s'", uri)


### PR DESCRIPTION
Chunk paths are no longer saved in the serialized `M3U8Stream`. They are always requested from the webpage.

Also added a hacky bit to skip downloading the image if it's from an archive