### PR TITLE
PDI CSV script formatting fix

### DIFF
--- a/scripts/pdi_to_csv.py
+++ b/scripts/pdi_to_csv.py
@@ -57,7 +57,7 @@ def pdi_to_csv(writer):
     header = "time, " + ", ".join(CITIES) + "\n"
     writer.write(header)
     for time in times:
-        row = str(time) + ", "
+        row = str(time)
         for city in CITIES:
             if time not in results[city]:
                 row += ", "


### PR DESCRIPTION
An extra comma is currently present in data rows.

Example output now:
```
time, dublin, fortlauderdale, lasvegas, london, miami, newjersey, newyork, prague
1577664388, , , , , , , , 15.15776
1577665807, , , , , , , , 15.66639
1577678501, , , , , , , , 18.08353
```

Interestingly, Pandas was still able to parse the previous outputs correctly.